### PR TITLE
fix: resolve flaky CSRF token verification tests

### DIFF
--- a/example.test.ts
+++ b/example.test.ts
@@ -78,7 +78,7 @@ describe("Elysia CSRF Plugin", () => {
     expect(invalidRes.status).toBe(403);
   });
 
-  test.skip("should accept POST with valid token", async () => {
+  test("should accept POST with valid token", async () => {
     const app = new Elysia()
       .use(csrf({ cookie: true }))
       .get("/token", ({ csrfToken }) => ({ token: csrfToken() }))
@@ -104,7 +104,7 @@ describe("Elysia CSRF Plugin", () => {
     expect(data).toHaveProperty("success", true);
   });
 
-  test.skip("should extract token from custom header", async () => {
+  test("should extract token from custom header", async () => {
     const app = new Elysia()
       .use(
         csrf({
@@ -143,7 +143,7 @@ describe("Elysia CSRF Plugin", () => {
     expect(successRes.status).toBe(200);
   });
 
-  test.skip("should allow custom ignored methods", async () => {
+  test("should allow custom ignored methods", async () => {
     const app = new Elysia()
       .use(
         csrf({
@@ -166,7 +166,7 @@ describe("Elysia CSRF Plugin", () => {
     expect(getRes.status).toBe(200);
   });
 
-  test.skip("should apply custom cookie configuration", async () => {
+  test("should apply custom cookie configuration", async () => {
     const app = new Elysia()
       .use(
         csrf({
@@ -191,7 +191,7 @@ describe("Elysia CSRF Plugin", () => {
     expect(cookies).toContain("SameSite=Strict");
   });
 
-  test.skip("should allow token reuse across requests", async () => {
+  test("should allow token reuse across requests", async () => {
     const app = new Elysia()
       .use(csrf({ cookie: true }))
       .get("/token", ({ csrfToken }) => ({ token: csrfToken() }))
@@ -227,7 +227,7 @@ describe("Elysia CSRF Plugin", () => {
     expect(req2.status).toBe(200);
   });
 
-  test.skip("should support multiple token sources", async () => {
+  test("should support multiple token sources", async () => {
     const app = new Elysia()
       .use(
         csrf({
@@ -279,7 +279,7 @@ describe("Elysia CSRF Plugin", () => {
     expect(headerRes.status).toBe(200);
   });
 
-  test.skip("should work with HTML forms", async () => {
+  test("should work with HTML forms", async () => {
     const app = new Elysia()
       .use(csrf({ cookie: true }))
       .get("/form", ({ csrfToken }) => {
@@ -320,7 +320,7 @@ describe("Elysia CSRF Plugin", () => {
     expect(submitRes.status).toBe(200);
   });
 
-  test.skip("should support SPA pattern", async () => {
+  test("should support SPA pattern", async () => {
     const app = new Elysia()
       .use(
         csrf({


### PR DESCRIPTION
Resolves #2 

### Solution

Added proper secret caching in the "derive" closure to ensure consistency within request context and modified verifyToken() to use fixed "saltLength" parameter instead of searching for first dash

### Testing

All 1,300 test runs pass (13 tests × 100 runs)
TypeScript compilation succeeds
 CI command verified: "bun test --randomize --rerun-each 100"

/claim #2 

<img width="422" height="158" alt="image" src="https://github.com/user-attachments/assets/a5886dbf-d5d7-4292-9009-880b79d76293" />

